### PR TITLE
Fix: The pages URL starting with a dot were not pre-rendered

### DIFF
--- a/PersonalSite/PersonalSite.csproj
+++ b/PersonalSite/PersonalSite.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BlazorWasmPreRendering.Build" Version="2.0.0-preview.1" />
+    <PackageReference Include="BlazorWasmPreRendering.Build" Version="2.0.0-preview.3" />
     <PackageReference Include="Humanizer" Version="2.14.1" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version=" 7.0.0-rc.1.22427.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.0-rc.1.22427.2" PrivateAssets="all" />

--- a/PersonalSite/PersonalSite.csproj
+++ b/PersonalSite/PersonalSite.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BlazorWasmPreRendering.Build" Version="2.0.0-preview.3" />
+    <PackageReference Include="BlazorWasmPreRendering.Build" Version="2.0.0-preview.3.1" />
     <PackageReference Include="Humanizer" Version="2.14.1" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version=" 7.0.0-rc.1.22427.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.0-rc.1.22427.2" PrivateAssets="all" />


### PR DESCRIPTION
Hi @marinasundstrom , I believe you remember that the "BlazorWasmPreRendering.Build" NuGet package could not pre-render some pages that have a URL parameter of its name starting a dot.

Now, the latest version of the "BlazorWasmPreRendering.Build" NuGet package has become to support such scenario.

So I'm going to send this pull request for upgrading the version of the "BlazorWasmPreRendering.Build" NuGet package.